### PR TITLE
@import: dependency was not found

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,9 @@ $ npm install modern-normalize
 
 ```css
 @import 'node_modules/modern-normalize/modern-normalize.css';
+
+/* If you use a module bundler like webpack, try this: */
+@import '~/modern-normalize/modern-normalize.css';
 ```
 
 or


### PR DESCRIPTION
I'm using webpack and the modern-normalize.css was not found with the import path provided in the readme. I had to use the tilde character to point to the node_modules folder. I thought it would be nice to share this tip with others.

Thanks for this normalizing style-sheet. It's perfect for projects where I don't care about non evergreen browsers 👍