### PR TITLE
Remove `details` normalization, update `summary` requirement

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -275,14 +275,6 @@ progress {
    ========================================================================== */
 
 /*
- * Add the correct display in Edge and Firefox.
- */
-
-details {
-	display: block;
-}
-
-/*
  * Add the correct display in all browsers.
  */
 

--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -275,7 +275,7 @@ progress {
    ========================================================================== */
 
 /*
- * Add the correct display in all browsers.
+ * Add the correct display in Chrome and Safari.
  */
 
 summary {


### PR DESCRIPTION
Support for the [`details`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Browser_compatibility) element was added in Firefox 49, along with `display: list-item` for the [`summary`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary#Browser_compatibility) element. Edge does not implement `details` yet, but since Edge is not supported by modern-normalize I've removed the rule entirely.