### PR TITLE
Use single quotes for quoted text in comments instead of backticks

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -98,7 +98,7 @@ strong {
 
 /**
  * 1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
- * 2. Correct the odd `em` font sizing in all browsers.
+ * 2. Correct the odd 'em' font sizing in all browsers.
  */
 
 code,
@@ -118,7 +118,7 @@ small {
 }
 
 /**
- * Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+ * Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
  */
 
 sub,
@@ -209,7 +209,7 @@ fieldset {
 }
 
 /**
- * Remove the padding so developers are not caught out when they zero out `fieldset` elements in all browsers.
+ * Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
  */
 
 legend {
@@ -253,7 +253,7 @@ progress {
 
 /**
  * 1. Correct the inability to style clickable types in iOS and Safari.
- * 2. Change font properties to `inherit` in Safari.
+ * 2. Change font properties to 'inherit' in Safari.
  */
 
 ::-webkit-file-upload-button {


### PR DESCRIPTION
CSS-in-JS is becoming wildly popular for styling client-side web applications.

A number of the tools/frameworks for styling in Javascript utilize [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to allow for real css syntax, as opposed to styles written in javascript objects. [Styled Components](https://github.com/styled-components) is probably the most popular example.

Since template literals use backticks, parsing css which contain backticks within comments is problematic, causing linting/parsing errors.

In order to copy-paste `modern-normalize.css` directly into one of these frameworks, we can simply use single quotes instead of backticks inside of the comments.

If it makes no difference otherwise (and maybe it does, please correct me if so), then why not? ;)