### PR TITLE
Don't inherit box-sizing by default

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -7,14 +7,10 @@
  * Use a better box model (opinionated).
  */
 
-html {
-	box-sizing: border-box;
-}
-
 *,
 *::before,
 *::after {
-	box-sizing: inherit;
+	box-sizing: border-box;
 }
 
 /**


### PR DESCRIPTION
We previously had `* { box-sizing: inherit }` in our design system, and chose to remove it because it caused more problems than it fixed. It's rather annoying to need `box-sizing: content-box` on a specific element, and having to write out:

```css
.target { box-sizing: content-box; }
.target *, .target *::before, .target *::after { box-sizing: border-box; }
```

And then realizing that's incorrect, it should actually be this:

```css
.target { box-sizing: content-box; }
.target::before, .target::after, .target > *, .target > *::before, .target > *::after  { box-sizing: border-box; }
```

The only time where having it this way actually helped was the times when a third-party widget expected to have `content-box` by default (and for some reason didn't set it itself). Which was actually pretty rare occurrence these days, and the `box-sizing: inherit` doesn't really help because you still need to debug why the layout is all wrong.

But when `content-box` was needed without being set, it was much easier to either wrap the third party component in a utility class that switched box models, or to just apply the style to the widget that required it with notes on why it was needed.

All in all, we found that `* { box-sizing: inherit }` does more harm than good. So I thought I'd suggest the change here