### PR TITLE
Remove `fieldset` padding

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -211,14 +211,6 @@ button:-moz-focusring,
 }
 
 /**
-Correct the padding in Firefox.
-*/
-
-fieldset {
-	padding: 0.35em 0.75em 0.625em;
-}
-
-/**
 Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
 */
 


### PR DESCRIPTION
It was fixed in Firefox 63 https://bugzilla.mozilla.org/show_bug.cgi?id=1483527