### PR TITLE
Fix 'hr' border color inheritance in Firefox

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -70,11 +70,13 @@ Grouping content
 */
 
 /**
-Add the correct height in Firefox.
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox.
 */
 
 hr {
-	height: 0;
+	height: 0; /* 1 */
+	color: inherit; /* 2 */
 }
 
 /*


### PR DESCRIPTION
Mirrored from [my PR towards csstools/normalize.css](https://github.com/csstools/normalize.css/pull/12)