### PR TITLE
Simplify selector

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -10,8 +10,8 @@ Use a better box model (opinionated).
 */
 
 *,
-*::before,
-*::after {
+::before,
+::after {
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
There is no need for "*" as ::before already means *::before