### PR TITLE
Make it easier to override `tab-size`

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -19,7 +19,7 @@ Use a better box model (opinionated).
 Use a more readable tab size (opinionated).
 */
 
-:root {
+html {
 	-moz-tab-size: 4;
 	tab-size: 4;
 }


### PR DESCRIPTION
change :root to html because `:root` has a higher specificity than `html`