### PR TITLE
Replace deprecated box-sizing fix by a better one

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -13,7 +13,9 @@ and https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-p
 html {
   box-sizing: border-box;
 }
-*, *:before, *:after {
+*,
+*::before,
+*::after {
   box-sizing: inherit;
 }
 

--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -6,13 +6,15 @@ Document
 */
 
 /**
-Use a better box model (opinionated).
+Apply a more natural box layout model to all elements (opinionated), but allowing components to change,
+compare https://www.paulirish.com/2012/box-sizing-border-box-ftw/ 
+and https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
 */
-
-*,
-::before,
-::after {
-	box-sizing: border-box;
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 
 /**


### PR DESCRIPTION
see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/. Even Paul Irish, original author of the fix currently part of modern-normalize, has agreed on this and edited his origjnal post back from 2021: https://www.paulirish.com/2012/box-sizing-border-box-ftw/

This will also fix https://github.com/sindresorhus/modern-normalize/issues/48.