### PR TITLE
Remove <hr> declarations

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -41,21 +41,6 @@ body {
 }
 
 /*
-Grouping content
-================
-*/
-
-/**
-1. Add the correct height in Firefox.
-2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
-*/
-
-hr {
-	height: 0; /* 1 */
-	color: inherit; /* 2 */
-}
-
-/*
 Text-level semantics
 ====================
 */

--- a/test/acceptance/chrome/rules.ts
+++ b/test/acceptance/chrome/rules.ts
@@ -37,7 +37,7 @@ test('Improve consistency of default fonts in all browsers.', async t => {
 		.expect(Selector('body').getStyleProperty('font-family')).eql(`system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`);
 });
 
-test('Add the correct height in Firefox.', async t => {
+test('<hr> should be the correct height.', async t => {
 	await t
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });

--- a/test/acceptance/chrome/validation.ts
+++ b/test/acceptance/chrome/validation.ts
@@ -37,7 +37,7 @@ test('Improve consistency of default fonts in all browsers.', async t => {
 		.expect(Selector('body').getStyleProperty('font-family')).notEql('system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"');
 });
 
-test('Add the correct height in Firefox.', async t => {
+test('<hr> should be the correct height.', async t => {
 	await t
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });

--- a/test/acceptance/firefox/rules.ts
+++ b/test/acceptance/firefox/rules.ts
@@ -37,7 +37,7 @@ test('Improve consistency of default fonts in all browsers.', async t => {
 		.expect(Selector('body').getStyleProperty('font-family')).eql(`system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`);
 });
 
-test('Add the correct height in Firefox.', async t => {
+test('<hr> should be the correct height.', async t => {
 	await t
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });

--- a/test/acceptance/firefox/validation.ts
+++ b/test/acceptance/firefox/validation.ts
@@ -37,7 +37,7 @@ test('Improve consistency of default fonts in all browsers.', async t => {
 		.expect(Selector('body').getStyleProperty('font-family')).notEql('system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"');
 });
 
-test('Add the correct height in Firefox.', async t => {
+test('<hr> should be the correct height.', async t => {
 	await t
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });

--- a/test/acceptance/safari/rules.ts
+++ b/test/acceptance/safari/rules.ts
@@ -38,7 +38,7 @@ test('Improve consistency of default fonts in all browsers.', async t => {
 		.expect(Selector('body').getStyleProperty('font-family')).eql(`system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`);
 });
 
-test('Add the correct height in Firefox.', async t => {
+test('<hr> should be the correct height.', async t => {
 	await t
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });

--- a/test/acceptance/safari/validation.ts
+++ b/test/acceptance/safari/validation.ts
@@ -38,7 +38,7 @@ test('Improve consistency of default fonts in all browsers.', async t => {
 		.expect(Selector('body').getStyleProperty('font-family')).notEql('system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"');
 });
 
-test('Add the correct height in Firefox.', async t => {
+test('<hr> should be the correct height.', async t => {
 	await t
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });


### PR DESCRIPTION
I believe the `<hr>` declarations do more harm than good. I have made a test document to show what I mean.
Source: https://codepen.io/atjn/pen/qBzXydJ

In these pictures, you see a comparison between Firefox (left), WebKit (middle), and Chromium (right).

In the first picture, the `modern-normalize` declarations are not enabled:

![Skærmbillede fra 2024-08-09 01-03-43](https://github.com/user-attachments/assets/50a5927e-d150-48ae-bb45-9757be5b3d9a)

As you can see, all browsers display the `<hr>` in the same way, so there is no need for normalization. (There is one exception when applying a color, but that can't be fixed with CSS, it requires changes to Chromium)

In the second picture,  the `modern-normalize` declarations are enabled:

![Skærmbillede fra 2024-08-09 01-04-57](https://github.com/user-attachments/assets/17d0ee50-680b-4a8b-aa72-889799ae6eac)

First, you can observe that the `height: 0px` declaration is no longer needed, since modern Firefox already uses that.
Second, you will notice that the `color: inherit` declaration did not normalize anything, instead it created a new compat issue when colors are inherited.

It might make sense to add `color: inherit` in #13 (`modern-base`) because it provides a better default, but it does not belong in the normalization sheet.