### PR TITLE
Remove `-moz-tab-size`

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -28,8 +28,7 @@ html {
 		'Segoe UI Emoji';
 	line-height: 1.15; /* 1. Correct the line height in all browsers. */
 	-webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
-	-moz-tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
-	tab-size: 4; /* 3 */
+	tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
 }
 
 /*

--- a/test/acceptance/firefox/rules.ts
+++ b/test/acceptance/firefox/rules.ts
@@ -10,7 +10,7 @@ test('Use a better box model (opinionated).', async t => {
 
 test('Use a more readable tab size (opinionated).', async t => {
 	await t
-		.expect(Selector('html').getStyleProperty('-moz-tab-size')).eql('4');
+		.expect(Selector('html').getStyleProperty('tab-size')).eql('4');
 });
 
 test('Correct the line height in all browsers.', async t => {


### PR DESCRIPTION
Firefox has supported `tab-size` for three years now, so the old prefixed declaration can be removed: https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size#browser_compatibility