### PR TITLE
Remove `text-transform` reset

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -162,15 +162,6 @@ textarea {
 }
 
 /**
-Remove the inheritance of text transform in Edge and Firefox.
-*/
-
-button,
-select {
-	text-transform: none;
-}
-
-/**
 Correct the inability to style clickable types in iOS and Safari.
 */
 

--- a/test/acceptance/chrome/rules.ts
+++ b/test/acceptance/chrome/rules.ts
@@ -93,7 +93,7 @@ test('Remove the margin in Firefox and Safari.', async t => {
 		.expect(Selector('[data-test--forms-1]').getStyleProperty('margin-left')).eql('0px');
 });
 
-test('Remove the inheritance of text transform in Firefox.', async t => {
+test('Text transform should not be inherited.', async t => {
 	await t
 		.expect(Selector('button[data-test--forms-1]').getStyleProperty('text-transform')).eql('none')
 		.expect(Selector('select[data-test--forms-1]').getStyleProperty('text-transform')).eql('none');

--- a/test/acceptance/chrome/validation.ts
+++ b/test/acceptance/chrome/validation.ts
@@ -93,7 +93,7 @@ test('Remove the margin in Firefox and Safari.', async t => {
 		.expect(Selector('[data-test--forms-1]').getStyleProperty('margin-left')).eql('0px');
 });
 
-test('Remove the inheritance of text transform in Firefox.', async t => {
+test('Text transform should not be inherited.', async t => {
 	await t
 		.expect(Selector('button[data-test--forms-1]').getStyleProperty('text-transform')).eql('none')
 		.expect(Selector('select[data-test--forms-1]').getStyleProperty('text-transform')).eql('none');

--- a/test/acceptance/firefox/rules.ts
+++ b/test/acceptance/firefox/rules.ts
@@ -93,7 +93,7 @@ test('Remove the margin in Firefox and Safari.', async t => {
 		.expect(Selector('[data-test--forms-1]').getStyleProperty('margin-left')).eql('0px');
 });
 
-test('Remove the inheritance of text transform in Firefox.', async t => {
+test('Text transform should not be inherited.', async t => {
 	await t
 		.expect(Selector('button[data-test--forms-1]').getStyleProperty('text-transform')).eql('none')
 		.expect(Selector('select[data-test--forms-1]').getStyleProperty('text-transform')).eql('none');

--- a/test/acceptance/firefox/validation.ts
+++ b/test/acceptance/firefox/validation.ts
@@ -93,7 +93,7 @@ test('Remove the margin in Firefox and Safari.', async t => {
 		.expect(Selector('[data-test--forms-1]').getStyleProperty('margin-left')).eql('0px');
 });
 
-test('Remove the inheritance of text transform in Firefox.', async t => {
+test('Text transform should not be inherited.', async t => {
 	await t
 		.expect(Selector('button[data-test--forms-1]').getStyleProperty('text-transform')).eql('none')
 		.expect(Selector('select[data-test--forms-1]').getStyleProperty('text-transform')).eql('none');

--- a/test/acceptance/safari/rules.ts
+++ b/test/acceptance/safari/rules.ts
@@ -95,7 +95,7 @@ test('Remove the margin in Firefox and Safari.', async t => {
 		.expect(Selector('[data-test--forms-1]').getStyleProperty('margin-left')).eql('0px');
 });
 
-test('Remove the inheritance of text transform in Firefox.', async t => {
+test('Text transform should not be inherited.', async t => {
 	await t
 		.expect(Selector('button[data-test--forms-1]').getStyleProperty('text-transform')).eql('none')
 		.expect(Selector('select[data-test--forms-1]').getStyleProperty('text-transform')).eql('none');

--- a/test/acceptance/safari/validation.ts
+++ b/test/acceptance/safari/validation.ts
@@ -94,7 +94,7 @@ test('Remove the margin in Firefox and Safari.', async t => {
 		.expect(Selector('[data-test--forms-1]').getStyleProperty('margin-left')).notEql('0px');
 });
 
-test('Remove the inheritance of text transform in Firefox.', async t => {
+test('Text transform should not be inherited.', async t => {
 	await t
 		.expect(Selector('button[data-test--forms-1]').getStyleProperty('text-transform')).eql('none')
 		.expect(Selector('select[data-test--forms-1]').getStyleProperty('text-transform')).eql('none');


### PR DESCRIPTION
Edge is no longer relevant, and Firefox fixed this issue five years ago: https://bugzilla.mozilla.org/show_bug.cgi?id=1481112

I did not remove the tests for this reset because I guess it is still useful to check that browsers actually do this themselves.