### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 12
+          - lts/*
+          - lts/-1
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
The node versions are too old to work on the latest MacOS, which is why the CI is failing. I have changed them to always be the latest two versions of node, which should mean this problem never reoccurs.

While I was at it, I also took the liberty of updating your actions.