### PR TITLE
Fix <table> declarations

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -130,7 +130,7 @@ Tabular data
 */
 
 /**
-1. Correct table border color inheritance in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+1. Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
 */
 
 table {

--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -130,11 +130,11 @@ Tabular data
 */
 
 /**
-1. Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
+Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
 */
 
 table {
-	border-color: currentcolor; /* 1 */
+	border-color: currentcolor;
 }
 
 /*

--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -130,13 +130,11 @@ Tabular data
 */
 
 /**
-1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
-2. Correct table border color inheritance in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+1. Correct table border color inheritance in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
 */
 
 table {
-	text-indent: 0; /* 1 */
-	border-color: inherit; /* 2 */
+	border-color: inherit; /* 1 */
 }
 
 /*

--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -134,7 +134,7 @@ Tabular data
 */
 
 table {
-	border-color: inherit; /* 1 */
+	border-color: currentcolor; /* 1 */
 }
 
 /*


### PR DESCRIPTION
The `text-indent` reset is fixed in all browsers, and I have tested that they work:
- Chrome: https://issues.chromium.org/issues/41478998
- Safari: https://bugs.webkit.org/show_bug.cgi?id=201297

The `border-color` inheritance issue is not yet fixed, but I believe the current implementation in `modern-normalize` is incorrect. I have made a test document to show what I mean.
Source: https://codepen.io/atjn/full/yLdowBM

In these pictures, you see a comparison between Firefox (left), WebKit (middle), and Chromium (right).

In the first picture, we see how browsers handle inheritance by default:

![Skærmbillede fra 2024-08-09 12-22-45](https://github.com/user-attachments/assets/5df3acef-cbe9-4355-9e57-47d86a12bde8)

I would argue that Firefox's approach is best here, and it is also the only one to pass the [web platform tests](https://wpt.fyi/results/html/rendering/non-replaced-elements/tables?q=table-border) for table borders, so we should replicate what Firefox does.

In the second picture, we see what `modern-normalize` currently does:

![Skærmbillede fra 2024-08-09 12-43-51](https://github.com/user-attachments/assets/c533f281-77ce-44b6-8279-0549688497bb)

This does not replicate Firefox's approach and is in my opinion not very usable.

In the third picture, we see what my proposed solution would do:

![Skærmbillede fra 2024-08-09 12-45-37](https://github.com/user-attachments/assets/f8d02c0f-374b-4211-9a83-5845121797cb)

This solution perfectly replicates Firefox's approach across all browsers.

