### PR TITLE
Remove mentions of Edge

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -62,7 +62,7 @@ Text-level semantics
 */
 
 /**
-Add the correct text decoration in Chrome, Edge, and Safari.
+Add the correct text decoration in Chrome and Safari.
 */
 
 abbr[title] {
@@ -70,7 +70,7 @@ abbr[title] {
 }
 
 /**
-Add the correct font weight in Edge and Safari.
+Add the correct font weight in Chrome and Safari.
 */
 
 b,

--- a/test/acceptance/chrome/rules.ts
+++ b/test/acceptance/chrome/rules.ts
@@ -42,12 +42,12 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });
 
-test('Add the correct text decoration in Edge, and Safari.', async t => {
+test('Add the correct text decoration in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });
 
-test('Add the correct font weight in Chrome, Edge, and Safari.', async t => {
+test('Add the correct font weight in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('b[data-test--bold]').getStyleProperty('font-weight')).eql('900')
 		.expect(Selector('strong[data-test--bold]').getStyleProperty('font-weight')).eql('900');

--- a/test/acceptance/chrome/validation.ts
+++ b/test/acceptance/chrome/validation.ts
@@ -42,12 +42,12 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });
 
-test('Add the correct text decoration in Edge, and Safari.', async t => {
+test('Add the correct text decoration in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });
 
-test('Add the correct font weight in Chrome, Edge, and Safari.', async t => {
+test('Add the correct font weight in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('b[data-test--bold]').getStyleProperty('font-weight')).notEql('900')
 		.expect(Selector('strong[data-test--bold]').getStyleProperty('font-weight')).notEql('900');

--- a/test/acceptance/firefox/rules.ts
+++ b/test/acceptance/firefox/rules.ts
@@ -42,12 +42,12 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });
 
-test('Add the correct text decoration in Chrome, Edge, and Safari.', async t => {
+test('Add the correct text decoration in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });
 
-test('Add the correct font weight in Chrome, Edge, and Safari.', async t => {
+test('Add the correct font weight in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('b[data-test--bold]').getStyleProperty('font-weight')).eql('900')
 		.expect(Selector('strong[data-test--bold]').getStyleProperty('font-weight')).eql('900');

--- a/test/acceptance/firefox/validation.ts
+++ b/test/acceptance/firefox/validation.ts
@@ -42,12 +42,12 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });
 
-test('Add the correct text decoration in Chrome, Edge, and Safari.', async t => {
+test('Add the correct text decoration in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });
 
-test('Add the correct font weight in Chrome, Edge, and Safari.', async t => {
+test('Add the correct font weight in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('b[data-test--bold]').getStyleProperty('font-weight')).eql('900')
 		.expect(Selector('strong[data-test--bold]').getStyleProperty('font-weight')).eql('900');

--- a/test/acceptance/safari/rules.ts
+++ b/test/acceptance/safari/rules.ts
@@ -43,13 +43,13 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });
 
-test('Add the correct text decoration in Edge, and Safari.', async t => {
+test('Add the correct text decoration in Chrome and Safari.', async t => {
 	// TODO: Why `text-decoration` is none?
 	// await t
 	// 	.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted');
 });
 
-test('Add the correct font weight in Chrome, Edge, and Safari.', async t => {
+test('Add the correct font weight in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('b[data-test--bold]').getStyleProperty('font-weight')).eql('900')
 		.expect(Selector('strong[data-test--bold]').getStyleProperty('font-weight')).eql('900');

--- a/test/acceptance/safari/validation.ts
+++ b/test/acceptance/safari/validation.ts
@@ -43,12 +43,12 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });
 
-test('Add the correct text decoration in Chrome, Edge, and Safari.', async t => {
+test('Add the correct text decoration in Chrome and Safari.', async t => {
 	// await t
 	// 	.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).notEql('underline dotted');
 });
 
-test('Add the correct font weight in Chrome, Edge, and Safari.', async t => {
+test('Add the correct font weight in Chrome and Safari.', async t => {
 	await t
 		.expect(Selector('b[data-test--bold]').getStyleProperty('font-weight')).notEql('900')
 		.expect(Selector('strong[data-test--bold]').getStyleProperty('font-weight')).notEql('900');


### PR DESCRIPTION
It is confusing that Edge is sometimes mentioned alongside / instead of Chrome. As far as I can tell, Chrome and Edge behave identically in all issues that `modern-normalize` fixes, and most comments only mention Chrome, so we should stick to that precedent unless something is actually different in Edge.

I left out one mention of Edge, which I expect will be removed in #77
