### PR TITLE
Remove Firefox focus reset

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -172,23 +172,6 @@ button,
 }
 
 /**
-Remove the inner border and padding in Firefox.
-*/
-
-::-moz-focus-inner {
-	border-style: none;
-	padding: 0;
-}
-
-/**
-Restore the focus styles unset by the previous rule.
-*/
-
-:-moz-focusring {
-	outline: 1px dotted ButtonText;
-}
-
-/**
 Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
 */
 

--- a/test/acceptance/chrome/rules.ts
+++ b/test/acceptance/chrome/rules.ts
@@ -107,14 +107,6 @@ test('Correct the inability to style clickable types in iOS and Safari.', async 
 		.expect(Selector('[type="submit"][data-test--forms-1]').getStyleProperty('-webkit-appearance')).eql('button');
 });
 
-test('Remove the inner border and padding in Firefox.', async t => {
-	// `-moz-focus-inner` does not exist in Chrome
-});
-
-test('Restore the focus styles unset by the previous rule.', async t => {
-	// `-moz-focusring` does not exist in Chrome
-});
-
 test('Correct the padding in Firefox.', async t => {
 	await t
 		.expect(Selector('fieldset[data-test--forms-2]').getStyleProperty('padding-top')).eql('5.6px')

--- a/test/acceptance/chrome/validation.ts
+++ b/test/acceptance/chrome/validation.ts
@@ -107,14 +107,6 @@ test('Correct the inability to style clickable types in iOS and Safari.', async 
 		.expect(Selector('[type="submit"][data-test--forms-1]').getStyleProperty('-webkit-appearance')).notEql('button');
 });
 
-test('Remove the inner border and padding in Firefox.', async t => {
-	// `-moz-focus-inner` does not exist in Chrome
-});
-
-test('Restore the focus styles unset by the previous rule.', async t => {
-	// `-moz-focusring` does not exist in Chrome
-});
-
 test('Correct the padding in Firefox.', async t => {
 	await t
 		.expect(Selector('fieldset[data-test--forms-2]').getStyleProperty('padding-top')).eql('5.6px')

--- a/test/acceptance/firefox/rules.ts
+++ b/test/acceptance/firefox/rules.ts
@@ -107,14 +107,6 @@ test('Correct the inability to style clickable types in iOS and Safari.', async 
 		.expect(Selector('[type="submit"][data-test--forms-1]').getStyleProperty('-webkit-appearance')).eql(undefined);
 });
 
-test('Remove the inner border and padding in Firefox.', async t => {
-	// TODO: Pseudo-elements selector not supported by testcafe (See https://github.com/DevExpress/testcafe/issues/2813).
-});
-
-test('Restore the focus styles unset by the previous rule.', async t => {
-	// TODO: Pseudo-elements selector not supported by testcafe (See https://github.com/DevExpress/testcafe/issues/2813).
-});
-
 test('Correct the padding in Firefox.', async t => {
 	await t
 		.expect(Selector('fieldset[data-test--forms-2]').getStyleProperty('padding-top')).eql('5.6px')

--- a/test/acceptance/firefox/validation.ts
+++ b/test/acceptance/firefox/validation.ts
@@ -107,14 +107,6 @@ test('Correct the inability to style clickable types in iOS and Safari.', async 
 		.expect(Selector('[type="submit"][data-test--forms-1]').getStyleProperty('-webkit-appearance')).eql(undefined);
 });
 
-test('Remove the inner border and padding in Firefox.', async t => {
-	// TODO: Pseudo-elements selector not supported by testcafe (See https://github.com/DevExpress/testcafe/issues/2813).
-});
-
-test('Restore the focus styles unset by the previous rule.', async t => {
-	// TODO: Pseudo-elements selector not supported by testcafe (See https://github.com/DevExpress/testcafe/issues/2813).
-});
-
 test('Correct the padding in Firefox.', async t => {
 	await t
 		.expect(Selector('fieldset[data-test--forms-2]').getStyleProperty('padding-top')).eql('5.6px')

--- a/test/acceptance/safari/rules.ts
+++ b/test/acceptance/safari/rules.ts
@@ -109,14 +109,6 @@ test('Correct the inability to style clickable types in iOS and Safari.', async 
 		.expect(Selector('[type="submit"][data-test--forms-1]').getStyleProperty('-webkit-appearance')).eql('button');
 });
 
-test('Remove the inner border and padding in Firefox.', async t => {
-	// `-moz-focus-inner` does not exist in Safari
-});
-
-test('Restore the focus styles unset by the previous rule.', async t => {
-	// `-moz-focusring` does not exist in Safari
-});
-
 test('Correct the padding in Firefox.', async t => {
 	await t
 		.expect(Selector('fieldset[data-test--forms-2]').getStyleProperty('padding-top')).eql('5.599999904632568px')

--- a/test/acceptance/safari/validation.ts
+++ b/test/acceptance/safari/validation.ts
@@ -108,14 +108,6 @@ test('Correct the inability to style clickable types in iOS and Safari.', async 
 		.expect(Selector('[type="submit"][data-test--forms-1]').getStyleProperty('-webkit-appearance')).notEql('button');
 });
 
-test('Remove the inner border and padding in Firefox.', async t => {
-	// `-moz-focus-inner` does not exist in Safari
-});
-
-test('Restore the focus styles unset by the previous rule.', async t => {
-	// `-moz-focusring` does not exist in Safari
-});
-
 test('Correct the padding in Firefox.', async t => {
 	await t
 		.expect(Selector('fieldset[data-test--forms-2]').getStyleProperty('padding-top')).eql('5.599999904632568px')


### PR DESCRIPTION
When this declaration was introduced more than 10 years ago, it was for a completely different browser than what we have now. Firefox's default implementation is now much better than this reset, as #55 also mentions. Since that issue was opened, they have also continued to improve the implementation, see fx https://bugzilla.mozilla.org/show_bug.cgi?id=1756002

I can't say for sure that there are no issues with Firefox's focus rings, but I can say for sure that these declarations are actively harmful and don't solve those theoretical issues anyway, so I definitely think they should be removed.

Closes #55