### PR TITLE
Remove Firefox invalid input reset

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -199,15 +199,6 @@ Restore the focus styles unset by the previous rule.
 }
 
 /**
-Remove the additional ':invalid' styles in Firefox.
-See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737
-*/
-
-:-moz-ui-invalid {
-	box-shadow: none;
-}
-
-/**
 Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
 */
 


### PR DESCRIPTION
The offending style declarations were removed from Firefox four years ago: https://bugzilla.mozilla.org/show_bug.cgi?id=1693969