### PR TITLE
Chrome supports <abbr> underline

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -61,7 +61,7 @@ Text-level semantics
 */
 
 /**
-Add the correct text decoration in Chrome and Safari.
+Add the correct text decoration in Safari.
 */
 
 abbr[title] {

--- a/test/acceptance/chrome/rules.ts
+++ b/test/acceptance/chrome/rules.ts
@@ -42,7 +42,7 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });
 
-test('Add the correct text decoration in Chrome and Safari.', async t => {
+test('Add the correct text decoration in Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });

--- a/test/acceptance/chrome/validation.ts
+++ b/test/acceptance/chrome/validation.ts
@@ -42,7 +42,7 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });
 
-test('Add the correct text decoration in Chrome and Safari.', async t => {
+test('Add the correct text decoration in Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });

--- a/test/acceptance/firefox/rules.ts
+++ b/test/acceptance/firefox/rules.ts
@@ -42,7 +42,7 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });
 
-test('Add the correct text decoration in Chrome and Safari.', async t => {
+test('Add the correct text decoration in Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });

--- a/test/acceptance/firefox/validation.ts
+++ b/test/acceptance/firefox/validation.ts
@@ -42,7 +42,7 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });
 
-test('Add the correct text decoration in Chrome and Safari.', async t => {
+test('Add the correct text decoration in Safari.', async t => {
 	await t
 		.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted rgb(0, 0, 0)');
 });

--- a/test/acceptance/safari/rules.ts
+++ b/test/acceptance/safari/rules.ts
@@ -43,7 +43,7 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).eql('2px');
 });
 
-test('Add the correct text decoration in Chrome and Safari.', async t => {
+test('Add the correct text decoration in Safari.', async t => {
 	// TODO: Why `text-decoration` is none?
 	// await t
 	// 	.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).eql('underline dotted');

--- a/test/acceptance/safari/validation.ts
+++ b/test/acceptance/safari/validation.ts
@@ -43,7 +43,7 @@ test('Add the correct height in Firefox.', async t => {
 		.expect(Selector('hr[data-test--hr]').getStyleProperty('height')).notEql('2px');
 });
 
-test('Add the correct text decoration in Chrome and Safari.', async t => {
+test('Add the correct text decoration in Safari.', async t => {
 	// await t
 	// 	.expect(Selector('abbr[data-test--abbr]').getStyleProperty('text-decoration')).notEql('underline dotted');
 });


### PR DESCRIPTION
Chrome added this declaration by default ten years ago: https://issues.chromium.org/issues/41109160