### PR TITLE
Remove <abbr> reset

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -46,14 +46,6 @@ Text-level semantics
 */
 
 /**
-Add the correct text decoration in Safari.
-*/
-
-abbr[title] {
-	text-decoration: underline dotted;
-}
-
-/**
 Add the correct font weight in Chrome and Safari.
 */
 


### PR DESCRIPTION
This reset has never worked because Safari doesn't support the specific shorthand we use. You can check out the implementation bug here: https://bugs.webkit.org/show_bug.cgi?id=230083

We could add a workaround to render an underline in Safari, but we don't have to because the next version of Safari will come with a baked-in workaround: https://bugs.webkit.org/show_bug.cgi?id=277889

It could take many months for the fix to be merged and released for us to test, so I think the best course of action is to remove this reset now, and then open an issue to track that the workaround is indeed present in the next version of Safari: #87