### PR TITLE
Fixes #93 - Delete `optgroup` element and add HTML code

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -126,7 +126,6 @@ Forms
 
 button,
 input,
-optgroup,
 select,
 textarea {
 	font-family: inherit; /* 1 */

--- a/test/page/with-css.html
+++ b/test/page/with-css.html
@@ -23,6 +23,9 @@
 			<input data-test--forms-1 type="number">
 			<input data-test--forms-1 type="search">
 			<optgroup data-test--forms-1></optgroup>
+			<select data-test--forms-1>
+				<optgroup data-test--forms-1 label="optgroup"></optgroup>
+			</select>
 			<select data-test--forms-1></select>
 			<textarea data-test--forms-1></textarea>
 			<input data-test--forms-1 type="button">

--- a/test/page/without-css.html
+++ b/test/page/without-css.html
@@ -20,6 +20,9 @@
 			<input data-test--forms-1 type="number">
 			<input data-test--forms-1 type="search">
 			<optgroup data-test--forms-1></optgroup>
+			<select data-test--forms-1>
+				<optgroup data-test--forms-1 label="optgroup"></optgroup>
+			</select>
 			<select data-test--forms-1></select>
 			<textarea data-test--forms-1></textarea>
 			<input data-test--forms-1 type="button">


### PR DESCRIPTION
Fixes #93 
As I mentioned in here [Delete `opgroup` element](https://github.com/sindresorhus/modern-normalize/issues/93#issue-2590065518), it's unnecessary and should be deleted, I've added new HTML code that has `select>optgroup`, I didn't delete `optgroup` but I think it should be deleted to.