### PR TITLE
Normalize comment format

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -15,8 +15,14 @@ Use a better box model (opinionated).
 	box-sizing: border-box;
 }
 
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the line height in all browsers.
+3. Prevent adjustments of font size after orientation changes in iOS.
+4. Use a more readable tab size (opinionated).
+*/
+
 html {
-	/* Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3) */
 	font-family:
 		system-ui,
 		'Segoe UI',
@@ -25,10 +31,10 @@ html {
 		Arial,
 		sans-serif,
 		'Apple Color Emoji',
-		'Segoe UI Emoji';
-	line-height: 1.15; /* 1. Correct the line height in all browsers. */
-	-webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
-	tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
+		'Segoe UI Emoji'; /* 1 */
+	line-height: 1.15; /* 2 */
+	-webkit-text-size-adjust: 100%; /* 3 */
+	tab-size: 4; /* 4 */
 }
 
 /*


### PR DESCRIPTION
Not sure if there's a reason the comments for `html` were formatted inline with declarations unlike all the other comments, so feel free to close if this isn't simply an oversight. 🙂 