### PR TITLE
Remove reset for `border-color` on table

### DIFF
--- a/modern-normalize.css
+++ b/modern-normalize.css
@@ -112,19 +112,6 @@ sup {
 }
 
 /*
-Tabular data
-============
-*/
-
-/**
-Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
-*/
-
-table {
-	border-color: currentcolor;
-}
-
-/*
 Forms
 =====
 */


### PR DESCRIPTION
Hello,

It appears that both Chrome and Safari now use `currentColor` as the default border colour for tables in line with the specs:

* https://developer.chrome.com/release-notes/149#remove_explicit_border_color_ua_stylesheet_rule_for_tables
* https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#Resolved-Issues (second "Resolved issue" section)

As a result, the reset for `border-color` on tables could be removed once Chrome 149+ adoption becomes more widespread. Safari 18+ already appears to have significant usage.

Cheers